### PR TITLE
Add repo consolidation script at ~/bin/consolidate

### DIFF
--- a/bin/consolidate
+++ b/bin/consolidate
@@ -1,107 +1,89 @@
 #!/bin/bash
 
-# Function to get the list of extensions from the arguments passed to the script
+# Functions:
+
+# Get the list of specified file extensions from script arguments
 get_extensions() {
-  # Check for input:
-  # If the user provides any arguments, store those as the list of file extensions to look for.
-  # If no arguments are given, leave extensions array empty to let the regex pattern search for everything.
   if [ $# -gt 0 ]; then
+    # Create an array for extensions
     EXTENSIONS=()
-    for var in $@
-    do
-      # Strip the . from the given extension if user gives the extension with a period (like .md)
-      var=${var/"."/}
-      EXTENSIONS+=("${var}")
+    for ext in "$@"; do
+      # Remove the leading dot if present
+      ext="${ext#.}"
+      EXTENSIONS+=("$ext")
     done
   else
-    EXTENSIONS=()
+    EXTENSIONS=()  # No extensions specified, match everything
   fi
 }
 
-# Function to get the current date in YYYY-MM-DD format
+# Get the current date in YYYY-MM-DD format
 get_current_date() {
   date +%F
 }
 
-# Function to ignore files based on .gitignore
+# Check if a file is ignored according to .gitignore
 is_ignored() {
   local filepath="$1"
   git check-ignore -q "$filepath"  # Returns 0 if ignored, 1 otherwise
-  return $?
 }
 
-# Function to process a single file
+# Process a single file: append its header and content to the output file
 process_file() {
   local filepath="$1"
-  local header="# $filepath"
   {
-    echo "$header"
-    echo ""  # Print a blank line
-    cat "$filepath"
-    echo ""  # Print a blank line after file content
+    echo "# $filepath"  # File header
+    echo ""            # Blank line
+    cat "$filepath"    # File content
+    echo ""            # Blank line after content
   } >> "$output_file"
 }
 
-# Function to traverse directories recursively
+# Recursively traverse directories to find and process files
 traverse_directory() {
   local dir="$1"
 
-  # The regex pattern starts with '.*', which searches for any matching characters
-  # '.' is a wildcard, while '*' means match as many occurrences of the preceding char
-  # '\.' escapes the '.' special char to search for the actual char
-  # () is a capturing group. The | character is an OR operator
-  # '$' indicates the preceding string should be followed by the end of line
+  # Construct regex pattern based on provided extensions
   if [ ${#EXTENSIONS[@]} -gt 0 ]; then
     EXTENSIONS_PATTERN=$(printf '\\|%s' "${EXTENSIONS[@]}")
-    pattern=".*\.\($EXTENSIONS_PATTERN\)$"
+    pattern=".*\.\($EXTENSIONS_PATTERN\)$"  # Pattern for matching specified extensions
   else
-    pattern=".*$"
+    pattern=".*$"  # Matches everything if no extensions specified
   fi
 
-  # Loop through each item in the directory
+  # Loop through entries in the specified directory
   for entry in "$dir"/*; do
-    # Check if entry exists (handles empty directories)
-    if [[ -e "$entry" ]]; then
-      if [[ -d "$entry" ]]; then
-        # Check if the directory is .git
+    if [[ -e "$entry" ]]; then  # Check if the entry exists
+      if [[ -d "$entry" ]]; then  # Process directories
         if [[ "$(basename "$entry")" != ".git" ]]; then
-          # Recursively traverse the directory
-          traverse_directory "$entry"
+          traverse_directory "$entry"  # Recursive call
         fi
-      elif [[ -f "$entry" ]]; then
-        # Ignore .gitignore files and files in .gitignore
+      elif [[ -f "$entry" ]]; then  # Process files
         if [[ "$(basename "$entry")" != ".gitignore" ]] && 
-          ! is_ignored "$entry" && 
-          [[ "$entry" =~ $pattern ]]; then # Check against regex pattern
-          process_file "$entry"
+           ! is_ignored "$entry" && 
+           [[ "$entry" =~ $pattern ]]; then  # Check if file matches regex
+          process_file "$entry"  # Process the file
         fi
       fi
     fi
   done
 }
 
-
-# Main function
+# Main function to execute the script logic
 main() {
-  get_extensions
+  get_extensions "$@"  # Pass all script arguments to get_extensions function
 
-  output_file="output-$(get_current_date).txt"
+  output_file="output-$(get_current_date).txt"  # Define the output file name
 
-  # Clear previous output file (if exists)
+  # Clear previous output file if it exists
   > "$output_file"
 
-  # Start traversing from the current directory
+  # Start the file traversal from the current directory
   traverse_directory "."
 
-  echo "Consolidation complete! Output saved in: $output_file"
+  echo "Consolidation complete! Output saved in: $output_file"  # Completion message
 }
 
-# Start the process.
+# Execution begins here
 echo "Consolidating..."
-
-# Execute main function
-main
-
-# Complete the process:
-# Inform the user that the operation is complete and let them know where the consolidated output has been saved.
-echo "Consolidation complete! See your output file at: "
+main "$@"  # Invoke main function with script arguments

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -11,13 +11,15 @@ if [ $# -gt 0 ]; then
   EXTENSIONS=()
   for var in $@
   do
+    # Strip the . from the given extension if user gives the extension with a period (like .md)
+    var=${var/"."/}
     EXTENSIONS+=("${var}")
   done
 else
   echo "0 arguments entered. Searching all files"
   EXTENSIONS=()
 fi
-echo ${EXTENSIONS}
+echo ${EXTENSIONS[@]}
 
 # Prepare a temporary file:
 # Create a temporary file that will hold patterns from the ".gitignore" file.

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -7,6 +7,7 @@ echo "Consolidating..."
 # If the user provides any arguments, store those as the list of file extensions to look for.
 # If no arguments are given, set a default list of extensions such as "txt", "sh", "md", and "csv".
 
+EXTENSIONS=()
 # Prepare a temporary file:
 # Create a temporary file that will hold patterns from the ".gitignore" file.
 
@@ -17,9 +18,23 @@ echo "Consolidating..."
 # Create an output file:
 # Get the current date and time, and create an output file named using this timestamp.
 
-# Find files:
+### Find files:
+
+# The regex pattern starts with '.*', which searches for any matching characters.
+# '.' is a wildcard, while '*' means match as many occurrences of the preceding char.
+# '\.' escapes the '.' special char to search for the actual char.
+# () is a capturing group. The | character is an OR operator
+# '$' indicates the preceding string should be followed by the end of line
+if [ ${#EXTENSIONS[@]} -gt 0 ]; then
+  EXTENSIONS_PATTERN=$(printf '\\|%s' "${EXTENSIONS[@]}")
+  REGEX_EXPRESSION=".*\.\($EXTENSIONS_PATTERN\)$"
+  echo "Regex Expression: $REGEX_EXPRESSION"
+else
+  REGEX_EXPRESSION=".*$"
+fi
 # Look for all files in the current directory and its subdirectories,
 # excluding the ".gitignore" file itself.
+find . -regex $REGEX_EXPRESSION
 # Filter these files based on the specified extensions.
 # Exclude any files that appear to be binary.
 # Exclude any files that match patterns listed in the ".gitignore".

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -5,9 +5,20 @@ echo "Consolidating..."
 
 # Check for input:
 # If the user provides any arguments, store those as the list of file extensions to look for.
-# If no arguments are given, set a default list of extensions such as "txt", "sh", "md", and "csv".
+# If no arguments are given, leave extensions array empty to let the regex pattern search for everything.
+if [ $# -gt 0 ]; then
+  echo "$# arguments entered"
+  EXTENSIONS=()
+  for var in $@
+  do
+    EXTENSIONS+=("${var}")
+  done
+else
+  echo "0 arguments entered. Searching all files"
+  EXTENSIONS=()
+fi
+echo ${EXTENSIONS}
 
-EXTENSIONS=()
 # Prepare a temporary file:
 # Create a temporary file that will hold patterns from the ".gitignore" file.
 
@@ -28,10 +39,10 @@ EXTENSIONS=()
 if [ ${#EXTENSIONS[@]} -gt 0 ]; then
   EXTENSIONS_PATTERN=$(printf '\\|%s' "${EXTENSIONS[@]}")
   REGEX_EXPRESSION=".*\.\($EXTENSIONS_PATTERN\)$"
-  echo "Regex Expression: $REGEX_EXPRESSION"
 else
   REGEX_EXPRESSION=".*$"
 fi
+echo "Regex Expression: $REGEX_EXPRESSION"
 # Look for all files in the current directory and its subdirectories,
 # excluding the ".gitignore" file itself.
 find . -regex $REGEX_EXPRESSION

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Start the process.
+echo "Consolidating..."
+
+# Check for input:
+# If the user provides any arguments, store those as the list of file extensions to look for.
+# If no arguments are given, set a default list of extensions such as "txt", "sh", "md", and "csv".
+
+# Prepare a temporary file:
+# Create a temporary file that will hold patterns from the ".gitignore" file.
+
+# Read the .gitignore file:
+# If the ".gitignore" file is present, read it and pull out lines that are not comments or blank.
+# Store these patterns in the temporary file.
+
+# Create an output file:
+# Get the current date and time, and create an output file named using this timestamp.
+
+# Find files:
+# Look for all files in the current directory and its subdirectories,
+# excluding the ".gitignore" file itself.
+# Filter these files based on the specified extensions.
+# Exclude any files that appear to be binary.
+# Exclude any files that match patterns listed in the ".gitignore".
+
+# Process each file:
+# For each file that matches the criteria:
+# - Write a header to the output file that includes the filename.
+# - Add the content of the file to the output file.
+# - Finish with a closing code block marker.
+
+# Clean up:
+# Delete the temporary file holding the patterns from the ".gitignore".
+
+# Complete the process:
+# Inform the user that the operation is complete and let them know where the consolidated output has been saved.
+echo "Consolidation complete! See your output file at: "

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -1,65 +1,106 @@
 #!/bin/bash
 
+# Function to get the list of extensions from the arguments passed to the script
+get_extensions() {
+  # Check for input:
+  # If the user provides any arguments, store those as the list of file extensions to look for.
+  # If no arguments are given, leave extensions array empty to let the regex pattern search for everything.
+  if [ $# -gt 0 ]; then
+    EXTENSIONS=()
+    for var in $@
+    do
+      # Strip the . from the given extension if user gives the extension with a period (like .md)
+      var=${var/"."/}
+      EXTENSIONS+=("${var}")
+    done
+  else
+    EXTENSIONS=()
+  fi
+}
+
+# Function to get the current date in YYYY-MM-DD format
+get_current_date() {
+  date +%F
+}
+
+# Function to ignore files based on .gitignore
+is_ignored() {
+  local filepath="$1"
+  git check-ignore -q "$filepath"  # Returns 0 if ignored, 1 otherwise
+  return $?
+}
+
+# Function to process a single file
+process_file() {
+  local filepath="$1"
+  local header="# $filepath"
+  {
+    echo "$header"
+    echo ""  # Print a blank line
+    cat "$filepath"
+    echo ""  # Print a blank line after file content
+  } >> "$output_file"
+}
+
+# Function to traverse directories recursively
+traverse_directory() {
+  local dir="$1"
+
+  # The regex pattern starts with '.*', which searches for any matching characters
+  # '.' is a wildcard, while '*' means match as many occurrences of the preceding char
+  # '\.' escapes the '.' special char to search for the actual char
+  # () is a capturing group. The | character is an OR operator
+  # '$' indicates the preceding string should be followed by the end of line
+  if [ ${#EXTENSIONS[@]} -gt 0 ]; then
+    EXTENSIONS_PATTERN=$(printf '\\|%s' "${EXTENSIONS[@]}")
+    pattern=".*\.\($EXTENSIONS_PATTERN\)$"
+  else
+    pattern=".*$"
+  fi
+
+  # Loop through each item in the directory
+  for entry in "$dir"/*; do
+    # Check if entry exists (handles empty directories)
+    if [[ -e "$entry" ]]; then
+      if [[ -d "$entry" ]]; then
+        # Check if the directory is .git
+        if [[ "$(basename "$entry")" != ".git" ]]; then
+          # Recursively traverse the directory
+          traverse_directory "$entry"
+        fi
+      elif [[ -f "$entry" ]]; then
+        # Ignore .gitignore files and files in .gitignore
+        if [[ "$(basename "$entry")" != ".gitignore" ]] && 
+          ! is_ignored "$entry" && 
+          [[ "$entry" =~ $pattern ]]; then # Check against regex pattern
+          process_file "$entry"
+        fi
+      fi
+    fi
+  done
+}
+
+
+# Main function
+main() {
+  get_extensions
+
+  output_file="output-$(get_current_date).txt"
+
+  # Clear previous output file (if exists)
+  > "$output_file"
+
+  # Start traversing from the current directory
+  traverse_directory "."
+
+  echo "Consolidation complete! Output saved in: $output_file"
+}
+
 # Start the process.
 echo "Consolidating..."
 
-# Check for input:
-# If the user provides any arguments, store those as the list of file extensions to look for.
-# If no arguments are given, leave extensions array empty to let the regex pattern search for everything.
-if [ $# -gt 0 ]; then
-  echo "$# arguments entered"
-  EXTENSIONS=()
-  for var in $@
-  do
-    # Strip the . from the given extension if user gives the extension with a period (like .md)
-    var=${var/"."/}
-    EXTENSIONS+=("${var}")
-  done
-else
-  echo "0 arguments entered. Searching all files"
-  EXTENSIONS=()
-fi
-echo ${EXTENSIONS[@]}
-
-# Prepare a temporary file:
-# Create a temporary file that will hold patterns from the ".gitignore" file.
-
-# Read the .gitignore file:
-# If the ".gitignore" file is present, read it and pull out lines that are not comments or blank.
-# Store these patterns in the temporary file.
-
-# Create an output file:
-# Get the current date and time, and create an output file named using this timestamp.
-
-### Find files:
-
-# The regex pattern starts with '.*', which searches for any matching characters.
-# '.' is a wildcard, while '*' means match as many occurrences of the preceding char.
-# '\.' escapes the '.' special char to search for the actual char.
-# () is a capturing group. The | character is an OR operator
-# '$' indicates the preceding string should be followed by the end of line
-if [ ${#EXTENSIONS[@]} -gt 0 ]; then
-  EXTENSIONS_PATTERN=$(printf '\\|%s' "${EXTENSIONS[@]}")
-  REGEX_EXPRESSION=".*\.\($EXTENSIONS_PATTERN\)$"
-else
-  REGEX_EXPRESSION=".*$"
-fi
-echo "Regex Expression: $REGEX_EXPRESSION"
-# Look for all files in the current directory and its subdirectories,
-# excluding the ".gitignore" file itself.
-find . -regex $REGEX_EXPRESSION
-# Filter these files based on the specified extensions.
-# Exclude any files that appear to be binary.
-# Exclude any files that match patterns listed in the ".gitignore".
-
-# Process each file:
-# For each file that matches the criteria:
-# - Write a header to the output file that includes the filename.
-# - Add the content of the file to the output file.
-# - Finish with a closing code block marker.
-
-# Clean up:
-# Delete the temporary file holding the patterns from the ".gitignore".
+# Execute main function
+main
 
 # Complete the process:
 # Inform the user that the operation is complete and let them know where the consolidated output has been saved.

--- a/bin/consolidate
+++ b/bin/consolidate
@@ -51,6 +51,9 @@ traverse_directory() {
     pattern=".*$"  # Matches everything if no extensions specified
   fi
 
+  # Array of filenames to exclude from processing
+  local EXCLUDED_FILES=("LICENSE" ".gitignore")
+
   # Loop through entries in the specified directory
   for entry in "$dir"/*; do
     if [[ -e "$entry" ]]; then  # Check if the entry exists
@@ -59,9 +62,19 @@ traverse_directory() {
           traverse_directory "$entry"  # Recursive call
         fi
       elif [[ -f "$entry" ]]; then  # Process files
-        if [[ "$(basename "$entry")" != ".gitignore" ]] && 
+        # Check if the file should be excluded
+        local exclude=false
+        for excluded in "${EXCLUDED_FILES[@]}"; do
+          if [[ "$(basename "$entry")" == "$excluded" ]]; then
+            exclude=true
+            break
+          fi
+        done
+
+        # Process the file only if it's not excluded, not ignored, and matches the pattern
+        if [[ "$exclude" == false ]] && 
            ! is_ignored "$entry" && 
-           [[ "$entry" =~ $pattern ]]; then  # Check if file matches regex
+           [[ "$entry" =~ $pattern ]]; then
           process_file "$entry"  # Process the file
         fi
       fi


### PR DESCRIPTION
# Description

This pull request introduces a new Bash script that recursively searches the current working directory for all files except those excluded in either the `.gitignore`, or those specified in the script (currently `.git/`, `LICENSE`, and `.gitignore`). It also accepts command line arguments of the specific extensions that the user wants to whitelist.

# Changes Made:

- Added a script at `bin/consolidate`
- Implemented the following features:
  - Traverses a directory and its subdirectories recursively
  - Checks if a file matches the exclude patterns and/or the extensions specified as arguments to the script
  - Logs the file's contents to a output file with the current date

# Code Overview

Here's a brief overview of the main sections of the added script:

## Functions:

- get_extensions: Captures file extensions specified as arguments when running the script.
- get_current_date: Returns the current date formatted as YYYY-MM-DD.
- is_ignored: Checks if a file is ignored using git check-ignore.
- process_file: Formats and appends content of a file to the output file.
- traverse_directory: Recursively searches directories for files with specified extensions if any, while respecting exclusion rules.

## Main Execution:

Once the script is executed, it starts with the main function that initializes the output file and begins traversing the directory, logging files that meet the rules to an output file.

# Usage

To use the script, run it from the command line provide it with file extensions as arguments. 
Example:

```bash
./consolidate txt # consolidates all text files, consolidating them into an output file named output-YYYY-MM-DD.txt.
./consolidate md .txt # works irrespective of the period being in the extension
consolidate # if the script is added to your path
```