### PR TITLE
refactor: modularise the configuration

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,0 +1,40 @@
+# Contains common configration for all machines
+
+{
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Set your time zone.
+  time.timeZone = "Asia/Singapore";
+
+  # Select internationalisation properties.
+  i18n.defaultLocale = "en_SG.UTF-8";
+
+  i18n.extraLocaleSettings = {
+    LC_ADDRESS = "en_SG.UTF-8";
+    LC_IDENTIFICATION = "en_SG.UTF-8";
+    LC_MEASUREMENT = "en_SG.UTF-8";
+    LC_MONETARY = "en_SG.UTF-8";
+    LC_NAME = "en_SG.UTF-8";
+    LC_NUMERIC = "en_SG.UTF-8";
+    LC_PAPER = "en_SG.UTF-8";
+    LC_TELEPHONE = "en_SG.UTF-8";
+    LC_TIME = "en_SG.UTF-8";
+  };
+
+  # Configure keymap in X11
+  services.xserver.xkb = {
+    layout = "us";
+    variant = "";
+  };
+
+  # Define a user account. Don't forget to set a password with ‘passwd’.
+  users.users.rafiq = {
+    isNormalUser = true;
+    description = "rafiq";
+    extraGroups = [ "networkmanager" "wheel" ];
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
+}

--- a/modules/home-editor.nix
+++ b/modules/home-editor.nix
@@ -1,0 +1,7 @@
+{self, pkgs, ...}:
+
+{
+  home.packages = [
+    self.packages.${pkgs.stdenv.system}.nvf
+  ];
+}

--- a/modules/home-git.nix
+++ b/modules/home-git.nix
@@ -1,0 +1,15 @@
+{
+  home.sessionVariables.GIT_CONFIG_GLOBAL = "$HOME/.config/git/config";
+
+  programs.git = {
+    enable = true;
+    userName = "Mohammad Rafiq";
+    userEmail = "mohammadrafiq567@gmail.com";
+    extraConfig = {
+      init.defaultBranch = "prime";
+      push.autoSetupRemote = true;
+      pull.rebase = false;
+      core.editor = "nvim";
+    };
+  };
+}

--- a/modules/home-sh.nix
+++ b/modules/home-sh.nix
@@ -1,0 +1,9 @@
+{
+  programs.bash = {
+    enable = true;
+    shellAliases = {
+      rebuild = "sudo nixos-rebuild switch --flake";
+      gs = "git status";
+    };
+  };
+}

--- a/modules/home-terminal.nix
+++ b/modules/home-terminal.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    kitty # default terminal emulator for hyprland
+  ];
+}

--- a/modules/home-tmux.nix
+++ b/modules/home-tmux.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.tmux = {
     enable = true;

--- a/modules/home-utils.nix
+++ b/modules/home-utils.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    fastfetch # system info
+    wl-clipboard # provides cli copy and paste commands
+  ];
+
+  programs = {
+    # man page summaries (activate with tldr <command>)
+    tealdeer = {
+      enable = true;
+      enableAutoUpdates = true;
+    };
+  };
+
+  services = {
+    # clipboard history (depends on wl-clipboard)
+    cliphist.enable = true;
+  };
+}

--- a/modules/home-utils.nix
+++ b/modules/home-utils.nix
@@ -1,6 +1,8 @@
 { pkgs, ... }:
 
 {
+  # TODO: Move wayland-specific stuff to a wayland config
+
   home.packages = with pkgs; [
     fastfetch # system info
     wl-clipboard # provides cli copy and paste commands

--- a/modules/home-wm.nix
+++ b/modules/home-wm.nix
@@ -1,0 +1,27 @@
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    systemd.enable = false; # Required for UWSM compat
+    systemd.variables = ["--all"];
+    # Use tha packages defined in the system configuration
+    package = null;
+    portalPackage = null;
+    settings = {
+      monitor = [
+        "HDMI-A-2, 3840x2160@60, 0x0, 2"
+        "DP-4, 1920x1080@60, -1920x0, 1"
+        ", preferred, auto, 1"
+      ];
+      "$terminal" = "kitty";
+      "$browser" = "firefox";
+      "$mainMod" = "SUPER";
+      bind = [
+        "$mainMod, Q, exec, uwsm app -- $terminal"
+        "$mainMod, W, killactive"
+        "$mainMod, E, exec, uwsm app -- $browser"
+        "$mainMod, M, exec, uwsm stop"
+      ];
+      debug.disable_logs = false;
+    };
+  };
+}

--- a/modules/networking.nix
+++ b/modules/networking.nix
@@ -1,0 +1,39 @@
+#
+# Common networking settings for all machines.
+# Anything system-specific should not be here.
+#
+{
+  networking = {
+    # Enable networkManager
+    # TODO: Look into the networkManager options.
+    networkmanager.enable = true;
+
+    # Configures a simple stateful firewall.
+    # By default, it doesn't allow any incoming connections.
+    firewall = {
+      enable = true; 
+      allowedTCPPorts = [ 
+        22 # SSH
+      ];
+      allowedUDPPorts = [];
+    };
+  };
+
+  # Add binary caches to avoid having to compile them
+  nix.settings = {
+    substituters = [
+      "https://hyprland.cachix.org" 
+      "https://cuda-maintainers.cachix.org" 
+      "https://nix-community.cachix.org" 
+    ];
+    trusted-public-keys = [
+      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" 
+      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
+  # TODO: look into openssh and tailscale settings.
+  services.openssh.enable = true;
+  services.tailscale.enable = true;
+}

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, inputs, ... }:
+let
+  hyprland-pkgs = inputs.hyprland.inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system};
+in
+{
+  hardware = {
+    graphics = {
+      enable = true;
+      package = hyprland-pkgs.mesa.drivers;
+      extraPackages = with pkgs; [
+        nvidia-vaapi-driver
+        ocl-icd
+        cudaPackages.cudatoolkit
+      ];
+    };
+    nvidia = {
+      open = true;
+      package = config.boot.kernelPackages.nvidiaPackages.latest;
+    };
+  };
+
+  services.xserver = {
+    enable = true;
+    videoDrivers = [ "nvidia" ];
+  };
+
+  environment.variables = {
+    NIXOS_OZONE_WL = "1"; # Hint to electron apps to use Wayland
+    LIBVA_DRIVER_NAME = "nvidia";
+    __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+    NVD_BACKEND = "direct"; # Set VAAPI driver backend
+  };
+
+  environment.systemPackages = with pkgs; [
+    clinfo
+    pciutils
+  ];
+}

--- a/modules/tmux.nix
+++ b/modules/tmux.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  programs.tmux = {
+    enable = true;
+    extraConfig = ''
+      set -g default-terminal "tmux-256color"
+      set -ag terminal-overrides ",xterm-256color:RGB"
+    '';
+  };
+}

--- a/modules/wm-hyprland.nix
+++ b/modules/wm-hyprland.nix
@@ -1,0 +1,32 @@
+{ inputs, pkgs, ... }:
+
+{
+  # Define the Universal Wayland Session Manager.
+  # This will start our compositor.
+  # TODO: Eventually move this to a common desktop module.
+  programs.uwsm = {
+    enable = true;
+    waylandCompositors.hyprland = {
+      prettyName = "Hyprland";
+      comment = "Hyprland compositor managed by UWSM";
+      binPath = "/run/current-system/sw/bin/Hyprland";
+    };
+  };
+
+  programs.hyprland = {
+    enable = true;
+    # Use the packages that we have defined as inputs in our flake.
+    package = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
+    portalPackage = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
+    # Enable sustemd integration
+    systemd.setPath.enable = true;
+    withUWSM = true;
+    # Enable compatibility with X11 apps
+    xwayland.enable = true;
+  };
+
+  services.hypridle.enable = true;
+
+  # Run a script that launches Hyprland through UWSM on login.
+  services.hyprland-tty-launch.enable = true;
+}

--- a/systems/nemesis/default.nix
+++ b/systems/nemesis/default.nix
@@ -2,16 +2,18 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ inputs, config, pkgs, ... }: let
-in {
+{ inputs, pkgs, ... }:
+
+{
   imports =
     [ # Include the results of the hardware scan.
       ./hardware-configuration.nix
       ../../scripts/hyprland-tty-launch.nix
       ../../modules/nvidia.nix # Graphics settings for Nvidia GPUs
+      ../../modules/networking.nix # Common networking config
     ];
 
-  # Bootloader.
+  # Bootloahttps://jira.xtremax.com/browse/GCCFMALRT-15450der.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
@@ -24,18 +26,6 @@ in {
 
   
   # Add hyprland.cachix.org as a binary cache for Hyprland
-  nix.settings = {
-    substituters = [
-      "https://hyprland.cachix.org" 
-      "https://cuda-maintainers.cachix.org" 
-      "https://nix-community.cachix.org" 
-    ];
-    trusted-public-keys = [
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" 
-      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    ];
-  };
 
   # Scripts
   services.hyprland-tty-launch.enable = true;
@@ -48,7 +38,6 @@ in {
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
 
   # Enable networking
-  networking.networkmanager.enable = true;
 
   # Set your time zone.
   time.timeZone = "Asia/Singapore";
@@ -102,9 +91,6 @@ in {
   # List services that you want to enable:
 
   # Enable the OpenSSH daemon.
-  services.openssh.enable = true;
-  services.tailscale.enable = true;
-
   programs.uwsm = {
     enable = true;
     waylandCompositors.hyprland = {
@@ -129,10 +115,8 @@ in {
   services.hypridle.enable = true;
 
   # Open ports in the firewall.
-  # networking.firewall.allowedTCPPorts = [ ... ];
   # networking.firewall.allowedUDPPorts = [ ... ];
   # Or disable the firewall altogether.
-  networking.firewall.enable = false;
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/systems/nemesis/default.nix
+++ b/systems/nemesis/default.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ inputs, pkgs, ... }:
+{ pkgs, ... }:
 
 {
   imports =
@@ -11,11 +11,10 @@
       ../../scripts/hyprland-tty-launch.nix
       ../../modules/nvidia.nix # Graphics settings for Nvidia GPUs
       ../../modules/networking.nix # Common networking config
+      ../../modules/wm-hyprland.nix # Enable the hyprland wm
     ];
 
-  # Bootloahttps://jira.xtremax.com/browse/GCCFMALRT-15450der.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
+  networking.hostName = "nemesis";
 
   # Allow nemesis to access files on the windows drive.
   fileSystems."/mnt/windows" =
@@ -24,20 +23,8 @@
       options = [ "rw" "uid=rafiq" ];
     };
 
-  
-  # Add hyprland.cachix.org as a binary cache for Hyprland
-
-  # Scripts
-  services.hyprland-tty-launch.enable = true;
-
-  networking.hostName = "nemesis"; # Define your hostname.
-  # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
-
-  # Configure network proxy if necessary
-  # networking.proxy.default = "http://user:password@proxy:port/";
-  # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
-
-  # Enable networking
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
 
   # Set your time zone.
   time.timeZone = "Asia/Singapore";
@@ -79,44 +66,6 @@
     firefox
     koboldcpp
   ];
-
-  # Some programs need SUID wrappers, can be configured further or are
-  # started in user sessions.
-  # programs.mtr.enable = true;
-  # programs.gnupg.agent = {
-  #   enable = true;
-  #   enableSSHSupport = true;
-  # };
-
-  # List services that you want to enable:
-
-  # Enable the OpenSSH daemon.
-  programs.uwsm = {
-    enable = true;
-    waylandCompositors.hyprland = {
-      prettyName = "Hyprland";
-      comment = "Hyprland compositor managed by UWSM";
-      binPath = "/run/current-system/sw/bin/Hyprland";
-    };
-  };
-
-  programs.hyprland = {
-    enable = true;
-    # Use the packages that we have defined as inputs in our flake.
-    package = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
-    portalPackage = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
-    # Enable sustemd integration
-    systemd.setPath.enable = true;
-    withUWSM = true;
-    # Enable compatibility with X11 apps
-    xwayland.enable = true;
-  };
-
-  services.hypridle.enable = true;
-
-  # Open ports in the firewall.
-  # networking.firewall.allowedUDPPorts = [ ... ];
-  # Or disable the firewall altogether.
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/systems/nemesis/default.nix
+++ b/systems/nemesis/default.nix
@@ -7,6 +7,7 @@
 {
   imports =
     [ # Include the results of the hardware scan.
+      ../../modules/common.nix
       ./hardware-configuration.nix
       ../../scripts/hyprland-tty-launch.nix
       ../../modules/nvidia.nix # Graphics settings for Nvidia GPUs
@@ -22,43 +23,6 @@
       fsType = "ntfs-3g";
       options = [ "rw" "uid=rafiq" ];
     };
-
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Set your time zone.
-  time.timeZone = "Asia/Singapore";
-
-  # Select internationalisation properties.
-  i18n.defaultLocale = "en_SG.UTF-8";
-
-  i18n.extraLocaleSettings = {
-    LC_ADDRESS = "en_SG.UTF-8";
-    LC_IDENTIFICATION = "en_SG.UTF-8";
-    LC_MEASUREMENT = "en_SG.UTF-8";
-    LC_MONETARY = "en_SG.UTF-8";
-    LC_NAME = "en_SG.UTF-8";
-    LC_NUMERIC = "en_SG.UTF-8";
-    LC_PAPER = "en_SG.UTF-8";
-    LC_TELEPHONE = "en_SG.UTF-8";
-    LC_TIME = "en_SG.UTF-8";
-  };
-
-  # Configure keymap in X11
-  services.xserver.xkb = {
-    layout = "us";
-    variant = "";
-  };
-
-  # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.rafiq = {
-    isNormalUser = true;
-    description = "rafiq";
-    extraGroups = [ "networkmanager" "wheel" ];
-  };
-
-  # Allow unfree packages
-  nixpkgs.config.allowUnfree = true;
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget

--- a/systems/nemesis/default.nix
+++ b/systems/nemesis/default.nix
@@ -3,12 +3,12 @@
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
 { inputs, config, pkgs, ... }: let
-  hyprland-pkgs = inputs.hyprland.inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system};
 in {
   imports =
     [ # Include the results of the hardware scan.
       ./hardware-configuration.nix
       ../../scripts/hyprland-tty-launch.nix
+      ../../modules/nvidia.nix # Graphics settings for Nvidia GPUs
     ];
 
   # Bootloader.
@@ -22,30 +22,6 @@ in {
       options = [ "rw" "uid=rafiq" ];
     };
 
-  # Graphics settings are defined here
-  hardware = {
-    graphics.enable = true;
-    graphics.package = hyprland-pkgs.mesa.drivers;
-    graphics.extraPackages = with pkgs; [
-      nvidia-vaapi-driver
-      ocl-icd
-      cudaPackages.cudatoolkit
-      # clinfo
-    ];
-    nvidia = {
-      open = true;
-      package = config.boot.kernelPackages.nvidiaPackages.stable;
-    };
-  };
-  environment.variables.NIXOS_OZONE_WL = "1"; # Hint to electron apps to use Wayland
-  environment.variables.LIBVA_DRIVER_NAME = "nvidia";
-  environment.variables.__GLX_VENDOR_LIBRARY_NAME = "nvidia";
-  environment.variables.NVD_BACKEND = "direct"; # Set VAAPI driver backend
-
-  services.xserver = {
-    enable = true;
-    videoDrivers = [ "nvidia" ];
-  };
   
   # Add hyprland.cachix.org as a binary cache for Hyprland
   nix.settings = {
@@ -112,7 +88,6 @@ in {
   # $ nix search wget
   environment.systemPackages = with pkgs; [
     firefox
-    clinfo
     koboldcpp
   ];
 

--- a/systems/nemesis/default.nix
+++ b/systems/nemesis/default.nix
@@ -15,6 +15,13 @@ in {
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Allow nemesis to access files on the windows drive.
+  fileSystems."/mnt/windows" =
+    { device = "/dev/nvme0n1p3";
+      fsType = "ntfs-3g";
+      options = [ "rw" "uid=rafiq" ];
+    };
+
   # Graphics settings are defined here
   hardware = {
     graphics.enable = true;

--- a/systems/nemesis/hardware-configuration.nix
+++ b/systems/nemesis/hardware-configuration.nix
@@ -25,12 +25,6 @@
       options = [ "fmask=0077" "dmask=0077" ];
     };
 
-  fileSystems."/mnt/windows" =
-    { device = "/dev/nvme0n1p3";
-      fsType = "ntfs-3g";
-      options = [ "rw" "uid=rafiq" ];
-    };
-
   swapDevices =
     [ { device = "/dev/disk/by-uuid/1fb29964-4a65-4cf4-9b45-9534d35845bc"; }
     ];

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -7,6 +7,7 @@
     ../../modules/home-sh.nix # bash and other shell specific configs
     ../../modules/home-wm.nix # window manager configs
     ../../modules/home-editor.nix # editor specific configs
+    ../../modules/home-terminal.nix # terminal emulator configs
   ];
 
   home = {
@@ -14,7 +15,6 @@
     homeDirectory = "/home/rafiq";
 
     packages = [
-      pkgs.kitty
       pkgs.fastfetch
       pkgs.wl-clipboard
     ];

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -2,7 +2,8 @@
 
 {
   imports = [
-    ../../modules/tmux.nix
+    ../../modules/home-git.nix
+    ../../modules/home-tmux.nix
   ];
 
   home = {
@@ -15,23 +16,15 @@
       pkgs.fastfetch
       pkgs.wl-clipboard
     ];
-    sessionVariables = {
-      GIT_CONFIG_GLOBAL = "$HOME/.config/git/config";
-    };
   };
   
   programs = {
-    git = {
+    bash = {
       enable = true;
-      userName = "Mohammad Rafiq";
-      userEmail = "mohammadrafiq567@gmail.com";
-      extraConfig = {
-        init.defaultBranch = "prime";
-        push.autoSetupRemote = true;
-        pull.rebase = false;
+      shellAliases = {
+        rebuild = "sudo nixos-rebuild switch --flake";
       };
     };
-
     tealdeer = {
       enable = true;
       enableAutoUpdates = true;

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -2,10 +2,11 @@
 
 {
   imports = [
-    ../../modules/home-git.nix
-    ../../modules/home-tmux.nix
-    ../../modules/home-sh.nix
-    ../../modules/home-wm.nix
+    ../../modules/home-git.nix # git specific configs
+    ../../modules/home-tmux.nix # tmux specific configs (might move this)
+    ../../modules/home-sh.nix # bash and other shell specific configs
+    ../../modules/home-wm.nix # window manager configs
+    ../../modules/home-editor.nix # editor specific configs
   ];
 
   home = {
@@ -13,7 +14,6 @@
     homeDirectory = "/home/rafiq";
 
     packages = [
-      self.packages.${pkgs.stdenv.system}.nvf
       pkgs.kitty
       pkgs.fastfetch
       pkgs.wl-clipboard

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../modules/home-git.nix
     ../../modules/home-tmux.nix
+    ../../modules/home-sh.nix
   ];
 
   home = {
@@ -19,12 +20,6 @@
   };
   
   programs = {
-    bash = {
-      enable = true;
-      shellAliases = {
-        rebuild = "sudo nixos-rebuild switch --flake";
-      };
-    };
     tealdeer = {
       enable = true;
       enableAutoUpdates = true;

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -5,6 +5,7 @@
     ../../modules/home-git.nix
     ../../modules/home-tmux.nix
     ../../modules/home-sh.nix
+    ../../modules/home-wm.nix
   ];
 
   home = {
@@ -26,32 +27,6 @@
     };
 
     home-manager.enable = true;
-  };
-
-  wayland.windowManager.hyprland = {
-    enable = true;
-    systemd.enable = false; # Required for UWSM compat
-    systemd.variables = ["--all"];
-    # Use tha packages defined in the system configuration
-    package = null;
-    portalPackage = null;
-    settings = {
-      monitor = [
-        "HDMI-A-2, 3840x2160@60, 0x0, 2"
-        "DP-4, 1920x1080@60, -1920x0, 1"
-        ", preferred, auto, 1"
-      ];
-      "$terminal" = "kitty";
-      "$browser" = "firefox";
-      "$mainMod" = "SUPER";
-      bind = [
-        "$mainMod, Q, exec, uwsm app -- $terminal"
-        "$mainMod, W, killactive"
-        "$mainMod, E, exec, uwsm app -- $browser"
-        "$mainMod, M, exec, uwsm stop"
-      ];
-      debug.disable_logs = false;
-    };
   };
 
   services = {

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -1,6 +1,10 @@
-{ self, config, pkgs, inputs, ... }:
+{ self, pkgs, ... }:
 
 {
+  imports = [
+    ../../modules/tmux.nix
+  ];
+
   home = {
     username = "rafiq";
     homeDirectory = "/home/rafiq";
@@ -33,13 +37,6 @@
       enableAutoUpdates = true;
     };
 
-    tmux = {
-      enable = true;
-      extraConfig = ''
-        set -g default-terminal "tmux-256color"
-        set -ag terminal-overrides ",xterm-256color:RGB"
-      '';
-    };
     home-manager.enable = true;
   };
 

--- a/users/rafiq/default.nix
+++ b/users/rafiq/default.nix
@@ -8,30 +8,19 @@
     ../../modules/home-wm.nix # window manager configs
     ../../modules/home-editor.nix # editor specific configs
     ../../modules/home-terminal.nix # terminal emulator configs
+    ../../modules/home-utils.nix # miscellaneous utilities
   ];
+
+  # This enables using home-manager from the command line.
+  programs.home-manager.enable = true;
 
   home = {
     username = "rafiq";
     homeDirectory = "/home/rafiq";
 
-    packages = [
-      pkgs.fastfetch
-      pkgs.wl-clipboard
-    ];
+    # This defines the version home-manager
+    # was originally bulit against on this system.
+    # Do not change it.
+    stateVersion = "25.05";
   };
-  
-  programs = {
-    tealdeer = {
-      enable = true;
-      enableAutoUpdates = true;
-    };
-
-    home-manager.enable = true;
-  };
-
-  services = {
-    cliphist.enable = true;
-  };
-
-  home.stateVersion = "25.05";
 }


### PR DESCRIPTION
closes #11 

The flake is as yet unmodularised.

All modules have been moved to a modules/ top level directory. Home-manager specific modules are prefixed with `home-`. The rest are meant to be imported by system configuration nix modules.